### PR TITLE
Add mocha to .jshintrc

### DIFF
--- a/boilerplate/.jshintrc
+++ b/boilerplate/.jshintrc
@@ -4,6 +4,7 @@
 	"bitwise": true,
 	"curly": true,
 	"immed": true,
+	"mocha": true,
 	"newcap": true,
 	"noarg": true,
 	"undef": true,

--- a/cli-boilerplate/.jshintrc
+++ b/cli-boilerplate/.jshintrc
@@ -4,6 +4,7 @@
 	"bitwise": true,
 	"curly": true,
 	"immed": true,
+	"mocha": true,
 	"newcap": true,
 	"noarg": true,
 	"undef": true,


### PR DESCRIPTION
This stops JSHint complaining about `it`.
```
test.js: line 5, col 1, 'it' is not defined.

1 error
``` 