### PR TITLE
chore(gitattributes): set eol to lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+
+*.js text eol=lf

--- a/boilerplate/.gitattributes
+++ b/boilerplate/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+
+*.js text eol=lf

--- a/cli-boilerplate/.gitattributes
+++ b/cli-boilerplate/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+
+*.js text eol=lf


### PR DESCRIPTION
For windows users
if you clone a repo with `text=auto`
All files will have `crlf` as their eol and you need to go through every single files to change the eol