### PR TITLE
Add support for Node.js v10 and drop support for v4

### DIFF
--- a/boilerplate/.travis.yml
+++ b/boilerplate/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -10,7 +10,7 @@
 		"url": "<%= website %>"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/cli-boilerplate/.travis.yml
+++ b/cli-boilerplate/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/cli-boilerplate/package.json
+++ b/cli-boilerplate/package.json
@@ -13,7 +13,7 @@
 		"<%= moduleName %>": "cli.js"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"


### PR DESCRIPTION
Node.js v4 is End-of-Life as of 2018-04-30. v10 was released 2018-04-24.

Reference: https://github.com/nodejs/Release