### PR TITLE
Bump dependency versions to fix tests crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
-		"ava": "^4.3.1",
-		"xo": "^0.51.0"
+		"ava": "^5.3.0",
+		"xo": "^0.54.2"
 	}
 }


### PR DESCRIPTION
Currently the template crashes for me when running tests, giving the error:

```
TypeError: Cannot read properties of undefined (reading 'getAllComments')
Occurred while linting [directory]\node-module-boilerplate\index.js:1
```

This seems to be related to [this issue in xo](https://github.com/xojs/xo/issues/718), and bumping the versions of the packages to the latest versions fixes this issue